### PR TITLE
Added --no-dev flag to composer

### DIFF
--- a/Boxfile
+++ b/Boxfile
@@ -17,7 +17,7 @@ web1:
     - app/storage/sessions
     - app/storage/views
   after_build:
-    - "if [ ! -f composer.phar ]; then curl -s http://getcomposer.org/installer | php; fi; php composer.phar install --prefer-source"
+    - "if [ ! -f composer.phar ]; then curl -s http://getcomposer.org/installer | php; fi; php composer.phar install --prefer-source --no-dev"
   after_deploy:
     - "php artisan cache:clear"
     - "rm -f app/storage/views/*"


### PR DESCRIPTION
Addresses Issue #17 involving the addition of the `--no-dev` flag to save on pagoda push time.
